### PR TITLE
Replaced Vite with Webpack and Babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ### **Week 3: React.js Fundamentals and State Management**
 
-- **Day 1:** Setting up React.js projects from scratch using Vite.
+- **Day 1:** Setting up React.js projects from scratch using Webpack and Babel.
 - **Day 2:** File organization and introduction to React.js routing; using `useState` in React.
 - **Day 3:** Introducing `useEffect` and building a single-day weather app.
 - **Day 4:** Mapping over data and expanding the weather app to display a week's forecast.


### PR DESCRIPTION
Although Vite is a good React templating system, it would render Webpack and Babel useless. Vite has its own configuration system that doesn't use Webpack and Babel.

When Webpack and Babel are introduced, they can be used to set up React from scratch. Then students can create their own React template(s). I've successfully taught my students how to do this.

In terms of jobs, there are many opportunities for Webpack, and barely any for Vite. It's beneficial to continue using Webpack and Babel throughout level 3 and level 4.

I think Vite is something the students can learn on their own outside of CodeX Academy.